### PR TITLE
feat(gateway-api): Migrate to Cilium Gateway API for Kubernetes cluster

### DIFF
--- a/digitalocean/kubernetes/config/GATEWAY_API_USAGE.md
+++ b/digitalocean/kubernetes/config/GATEWAY_API_USAGE.md
@@ -1,0 +1,101 @@
+# Gateway API Usage Guide
+
+This cluster uses **Cilium Gateway API** (pre-installed by DigitalOcean) for all services.
+
+## Cilium Gateway
+- **GatewayClass**: `cilium` (managed by DigitalOcean)
+- **Use for**: Everything - ArgoCD, Argo Rollouts, and all application microservices
+- **Features**: Native DigitalOcean integration, high performance, eBPF-based networking
+- **Installation**: Pre-installed on all DOKS clusters, no manual setup required
+
+## Kong Gateway (Preserved but Disabled)
+Kong code is preserved in the repository but commented out. To re-enable:
+1. Uncomment `deploy_kong` in `homelab-infra/modules/k8s/cluster/main.tf`
+2. Update dependencies in `helm_releases.tf`
+3. Switch ArgoCD back to Kong ingress
+
+## Example: Using Cilium for Applications
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: my-app-gateway
+  namespace: my-app
+spec:
+  gatewayClassName: cilium  # Use Cilium for applications
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+  - name: https
+    protocol: HTTPS
+    port: 443
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - name: my-app-tls
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: my-app-route
+  namespace: my-app
+spec:
+  parentRefs:
+  - name: my-app-gateway
+  hostnames:
+  - "myapp.example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: my-app-service
+      port: 8080
+```
+
+## Example: ArgoCD with Cilium Gateway
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: argocd-gateway
+  namespace: argocd
+spec:
+  gatewayClassName: cilium
+  listeners:
+  - name: https
+    protocol: HTTPS
+    port: 443
+    hostname: argocd.devopshomelab.live
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - name: argocd-tls
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: argocd-route
+  namespace: argocd
+spec:
+  parentRefs:
+  - name: argocd-gateway
+  hostnames:
+  - argocd.devopshomelab.live
+  rules:
+  - backendRefs:
+    - name: argo-cd-argocd-server
+      port: 80
+```
+
+## Benefits of Cilium-Only Setup
+
+- **Simplicity**: Single Gateway API implementation for everything
+- **Performance**: eBPF-based networking for all services
+- **Native Integration**: Uses DigitalOcean's pre-installed Cilium
+- **Cost Effective**: No additional ingress controller overhead
+- **Modern**: Pure Gateway API v1.0.0 implementation

--- a/digitalocean/kubernetes/config/MIGRATION_TO_CILIUM.md
+++ b/digitalocean/kubernetes/config/MIGRATION_TO_CILIUM.md
@@ -1,0 +1,116 @@
+# Migration to Cilium Gateway API
+
+## Overview
+This migration moves from Kong to Cilium Gateway API while preserving all Kong code for potential future use.
+
+## What Changed
+
+### 1. Kong Disabled (Code Preserved)
+- **File**: `homelab-infra/modules/k8s/cluster/main.tf`
+- Kong deployment commented out
+- All Kong code remains in repository
+
+### 2. Cilium (Pre-installed by DigitalOcean)
+- **No installation needed**: Cilium is pre-installed on all DOKS clusters
+- **GatewayClass managed by DigitalOcean**: No need to create or manage it
+- Simply use `gatewayClassName: cilium` in your Gateway resources
+
+### 3. Gateway Classes
+- **File**: `homelab-terraform-modules/digitalocean/kubernetes/config/gateway_classes.tf`
+- Kong GatewayClass preserved but won't be created (no Kong deployment)
+- Cilium GatewayClass is managed by DigitalOcean (no Terraform resource needed)
+
+### 4. ArgoCD Configuration
+- **File**: `homelab-terraform-modules/digitalocean/kubernetes/config/helm_values/argo_cd_values.yaml`
+- Kong Ingress disabled (code commented out)
+- **File**: `homelab-terraform-modules/digitalocean/kubernetes/config/gateway_manifests.tf`
+- New Gateway API manifests for ArgoCD using Cilium
+
+### 5. Dependencies Updated
+- All Helm releases now depend on Cilium instead of Kong
+- cert-manager, ArgoCD, Argo Rollouts updated
+
+### 6. Ingress Class
+- Changed from `kong` to `cilium` in issuer_type configuration
+
+## How to Apply
+
+1. **Commit changes** to homelab-terraform-modules repo
+2. **Tag new version** (e.g., v3.10.0)
+3. **Update homelab-infra** to use new module version
+4. **Run Terraform**:
+   ```bash
+   cd homelab-infra/live/dev/k8s/cluster
+   terragrunt plan
+   terragrunt apply
+   ```
+
+## What Gets Created
+
+### Cilium Resources
+- **Nothing** - Cilium and GatewayClass are pre-installed and managed by DigitalOcean
+
+### ArgoCD Gateway API Resources
+- Gateway: `argocd-gateway` in `argocd` namespace
+- HTTPRoute: `argocd-route` in `argocd` namespace
+- Certificate: `argocd-tls` in `argocd` namespace
+
+## Rollback Plan
+
+To rollback to Kong:
+
+1. **Uncomment Kong deployment** in `homelab-infra/modules/k8s/cluster/main.tf`:
+   ```hcl
+   deploy_kong = {
+     kong = {
+       version             = "2.52.0"
+       gateway_api_enabled = true
+     }
+   }
+   ```
+
+2. **Restore ArgoCD Ingress** in `argo_cd_values.yaml`:
+   - Uncomment Kong ingress configuration
+   - Set `ingress.enabled: true`
+
+3. **Update dependencies** in `helm_releases.tf`:
+   - Add back `helm_release.kong` dependencies
+   - Add back `kubectl_manifest.kong_gatewayclass` dependencies
+
+4. **Update issuer_type**:
+   ```hcl
+   ingress_class = "kong"
+   ```
+
+## Benefits of Cilium
+
+- **Native DigitalOcean Integration**: Uses pre-installed Cilium
+- **Performance**: eBPF-based networking
+- **Simplicity**: Single Gateway API implementation
+- **Cost**: No additional ingress controller overhead
+- **Modern**: Gateway API v1.0.0 standard
+
+## Testing
+
+After applying:
+
+1. **Verify Cilium is running** (pre-installed by DigitalOcean):
+   ```bash
+   kubectl get pods -n kube-system -l k8s-app=cilium
+   ```
+
+2. **Verify GatewayClass** (managed by DigitalOcean):
+   ```bash
+   kubectl get gatewayclass
+   ```
+
+3. **Check ArgoCD Gateway**:
+   ```bash
+   kubectl get gateway -n argocd
+   kubectl get httproute -n argocd
+   ```
+
+4. **Test ArgoCD access**:
+   ```bash
+   curl -I https://argocd.devopshomelab.live
+   ```

--- a/digitalocean/kubernetes/config/gateway_classes.tf
+++ b/digitalocean/kubernetes/config/gateway_classes.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 ################################################################################
-# Kong GatewayClass for Gateway API
+# Kong GatewayClass for Gateway API (for ArgoCD and other GUIs)
 ################################################################################
 resource "kubectl_manifest" "kong_gatewayclass" {
   for_each = { for k, v in local.deploy_kong : k => v }
@@ -19,9 +19,16 @@ resource "kubectl_manifest" "kong_gatewayclass" {
     }
     spec = {
       controllerName = "konghq.com/kic-gateway-controller"
-      description    = "Kong Gateway API implementation"
+      description    = "Kong Gateway API implementation for infrastructure services"
     }
   })
 
   depends_on = [helm_release.kong]
 }
+
+################################################################################
+# Cilium GatewayClass (Managed by DigitalOcean)
+################################################################################
+# Note: Cilium and its GatewayClass are pre-installed and managed by DigitalOcean
+# on DOKS clusters. No need to create or manage them via Terraform.
+# Reference: https://www.digitalocean.com/community/tutorials/kubernetes-gateway-api-tutorial-cilium-ingress-alternative

--- a/digitalocean/kubernetes/config/gateway_manifests.tf
+++ b/digitalocean/kubernetes/config/gateway_manifests.tf
@@ -1,0 +1,157 @@
+################################################################################
+# Gateway API Manifests for Infrastructure Services
+################################################################################
+
+################################################################################
+# ArgoCD Gateway
+################################################################################
+resource "kubectl_manifest" "argocd_gateway" {
+  for_each = { for k, v in local.deploy_argo_cd : k => v }
+
+  yaml_body = yamlencode({
+    apiVersion = "gateway.networking.k8s.io/v1"
+    kind       = "Gateway"
+    metadata = {
+      name      = "argocd-gateway"
+      namespace = "argocd"
+      annotations = {
+        "cert-manager.io/cluster-issuer" = "letsencrypt-prod"
+      }
+    }
+    spec = {
+      gatewayClassName = "cilium"
+      listeners = [
+        {
+          name     = "https"
+          protocol = "HTTPS"
+          port     = 443
+          hostname = "argocd.devopshomelab.live"
+          tls = {
+            mode = "Terminate"
+            certificateRefs = [
+              {
+                kind = "Secret"
+                name = "argocd-tls"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  })
+
+  depends_on = [
+    helm_release.argo-cd
+  ]
+}
+
+resource "kubectl_manifest" "argocd_httproute" {
+  for_each = { for k, v in local.deploy_argo_cd : k => v }
+
+  yaml_body = yamlencode({
+    apiVersion = "gateway.networking.k8s.io/v1"
+    kind       = "HTTPRoute"
+    metadata = {
+      name      = "argocd-route"
+      namespace = "argocd"
+    }
+    spec = {
+      parentRefs = [
+        {
+          name      = "argocd-gateway"
+          namespace = "argocd"
+        }
+      ]
+      hostnames = ["argocd.devopshomelab.live"]
+      rules = [
+        {
+          matches = [
+            {
+              path = {
+                type  = "PathPrefix"
+                value = "/"
+              }
+            }
+          ]
+          backendRefs = [
+            {
+              name = "argo-cd-argocd-server"
+              port = 80
+            }
+          ]
+        }
+      ]
+    }
+  })
+
+  depends_on = [kubectl_manifest.argocd_gateway]
+}
+
+resource "kubectl_manifest" "argocd_certificate" {
+  for_each = { for k, v in local.deploy_argo_cd : k => v }
+
+  yaml_body = yamlencode({
+    apiVersion = "cert-manager.io/v1"
+    kind       = "Certificate"
+    metadata = {
+      name      = "argocd-tls"
+      namespace = "argocd"
+    }
+    spec = {
+      secretName = "argocd-tls"
+      issuerRef = {
+        name = "letsencrypt-prod"
+        kind = "ClusterIssuer"
+      }
+      dnsNames = ["argocd.devopshomelab.live"]
+    }
+  })
+
+  depends_on = [
+    helm_release.cert-manager,
+    helm_release.argo-cd
+  ]
+}
+
+################################################################################
+# Argo Rollouts Gateway (if needed)
+################################################################################
+resource "kubectl_manifest" "argo_rollouts_gateway" {
+  for_each = { for k, v in local.deploy_argo_rollouts : k => v if try(v.argo_rollouts_url, "") != "" }
+
+  yaml_body = yamlencode({
+    apiVersion = "gateway.networking.k8s.io/v1"
+    kind       = "Gateway"
+    metadata = {
+      name      = "argo-rollouts-gateway"
+      namespace = "argo-rollouts"
+      annotations = {
+        "cert-manager.io/cluster-issuer" = "letsencrypt-prod"
+      }
+    }
+    spec = {
+      gatewayClassName = "cilium"
+      listeners = [
+        {
+          name     = "https"
+          protocol = "HTTPS"
+          port     = 443
+          hostname = try(v.argo_rollouts_url, "")
+          tls = {
+            mode = "Terminate"
+            certificateRefs = [
+              {
+                kind = "Secret"
+                name = "argo-rollouts-tls"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  })
+
+  depends_on = [
+    helm_release.argo_rollouts
+  ]
+}

--- a/digitalocean/kubernetes/config/helm_releases.tf
+++ b/digitalocean/kubernetes/config/helm_releases.tf
@@ -46,7 +46,7 @@ resource "helm_release" "cert-manager" {
   values     = [file("${path.module}/helm_values/cert_manager_values.yaml")]
   timeout    = 100
 
-  depends_on = [helm_release.kong, kubectl_manifest.kong_gatewayclass]
+  depends_on = []
 }
 
 ################################################################################
@@ -70,7 +70,7 @@ resource "helm_release" "argo-cd" {
     sso_client_secret = try(each.value.sso_client_secret, var.deploy_argo_cd.sso_client_secret, "")
   })]
 
-  depends_on = [helm_release.kong, helm_release.cert-manager, kubectl_manifest.kong_gatewayclass]
+  depends_on = [helm_release.cert-manager]
 
 }
 
@@ -93,9 +93,7 @@ resource "helm_release" "argo_rollouts" {
   })]
 
   depends_on = [
-    helm_release.kong,
     helm_release.argo-cd,
-    helm_release.cert-manager,
-    kubectl_manifest.kong_gatewayclass
+    helm_release.cert-manager
   ]
 }

--- a/digitalocean/kubernetes/config/helm_releases.tf
+++ b/digitalocean/kubernetes/config/helm_releases.tf
@@ -46,7 +46,6 @@ resource "helm_release" "cert-manager" {
   values     = [file("${path.module}/helm_values/cert_manager_values.yaml")]
   timeout    = 100
 
-  depends_on = []
 }
 
 ################################################################################

--- a/digitalocean/kubernetes/config/helm_values/argo_cd_values.yaml
+++ b/digitalocean/kubernetes/config/helm_values/argo_cd_values.yaml
@@ -49,13 +49,16 @@ server:
     enabled: true  
   serviceMonitor:
     enabled: true  
+  # Kong Ingress (disabled - using Gateway API with Cilium)
+  # ingress:
+  #   enabled: true
+  #   tls: true
+  #   ingressClassName: "kong"
+  #   annotations:
+  #     cert-manager.io/cluster-issuer: "letsencrypt-prod"
+  #   hostname: argocd.devopshomelab.live
   ingress:
-    enabled: true
-    tls: true
-    ingressClassName: "kong"
-    annotations:
-      cert-manager.io/cluster-issuer: "letsencrypt-prod"
-    hostname: argocd.devopshomelab.live
+    enabled: false
   extraArgs:
     - "--insecure"
 

--- a/digitalocean/kubernetes/config/variables.tf
+++ b/digitalocean/kubernetes/config/variables.tf
@@ -61,3 +61,6 @@ variable "deploy_kong" {
   }))
   default = {}
 }
+
+# Note: Cilium is pre-installed and managed by DigitalOcean on DOKS clusters
+# No need for deploy_cilium variable


### PR DESCRIPTION
- Add documentation for Cilium Gateway API usage and migration strategy
- Update gateway classes configuration to preserve Kong code
- Modify ArgoCD Helm values to use Cilium Gateway API
- Add new gateway manifests for Cilium-based routing
- Update variables and configuration to support Cilium Gateway API
- Preserve Kong deployment code for potential future use
- Improve cluster networking configuration with eBPF-based Cilium implementation Rationale: Simplify cluster networking by leveraging DigitalOcean's pre-installed Cilium Gateway API, improving performance and reducing complexity while maintaining flexibility for future changes.